### PR TITLE
Add required code change for Renown Level 62.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,15 @@ In the US, see e.g. [Galoob v. Nintendo](https://www.lexisnexis.com/community/ca
 
 # Getting it running
 
-To expose VenturePlan's internal data you will need to edit its source code. Open up Interface/Addons/VenturePlan/vs.lua in a text editor, and insert the line `_G[_] = T` in the first blank space. It should look like this when you're done:
+To expose VenturePlan's internal data you will need to edit its source code. First, ensure that you are on the latest version, `4.16a`. Then open up `Interface/Addons/VenturePlan/vs.lua` in a text editor, and insert the line `_G[_] = T` in the first blank space. It should look like this when you're done:
 
 ![Notepad preview of changed file](img/notepad.png)
 
 This makes the internal data of the addon (`T`) available to other addons (by putting it in the global table, `_G`, which every addon has available to it). In general you shouldn't be messing with addons like this, because it's a great way of getting hacked, but in this case there's no way around it. _caveat emptor_
+
+# Hotfixing the Code for Renown Level 62 and Above
+
+At renown level 62, you will gain your 21st companion. VenturePlan is coded to handle a maximum to 20 companions. You will start seeing errors about `self.info` being `nil`. To fix this, change line 1960 (in version `4.16a`) from `for i=1,20 do` to `for i=1,99 do`. This will add support up to 99 companions.
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This makes the internal data of the addon (`T`) available to other addons (by pu
 
 # Hotfixing the Code for Renown Level 62 and Above
 
-At renown level 62, you will gain your 21st companion. VenturePlan is coded to handle a maximum to 20 companions. You will start seeing errors about `self.info` being `nil`. To fix this, change line 1960 (in version `4.16a`) from `for i=1,20 do` to `for i=1,99 do`. This will add support up to 99 companions.
+At renown level 62, you will gain your 21st companion. VenturePlan is coded to handle a maximum to 20 companions. You will start seeing errors about `self.info` being `nil`. To fix this, edit the file `_retail_/Interface/AddOns/VenturePlan/Widgets.lua`: change line 1960 (in version `4.16a`) from `for i=1,20 do` to `for i=1,99 do`. This will add support up to 99 companions.
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -63,5 +63,7 @@ Many thanks to:
 * siweia
 * LostTemple1990
 * epiktetov
+* FlipperPA
+* cremor
 
 for contributions and support, as well as to the original author for a great addon.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ This makes the internal data of the addon (`T`) available to other addons (by pu
 
 At renown level 62, you will gain your 21st companion. VenturePlan is coded to handle a maximum to 20 companions. You will start seeing errors about `self.info` being `nil`. To fix this, edit the file `_retail_/Interface/AddOns/VenturePlan/Widgets.lua`: change line 1960 (in version `4.16a`) from `for i=1,20 do` to `for i=1,99 do`. This will add support up to 99 companions.
 
+After completing this change, the code should look like this:
+
+```lua
+s.companions = {}
+for i=1,99 do
+    t = CreateObject("FollowerListButton", f, false)
+    t:SetPoint("TOPLEFT", ((i-1)%4)*76+14, -math.floor((i-1)/4)*72-130)
+    s.companions[i] = t
+end
+```
+
 # Contributing
 
 If you have updates to the spell list you'd like to include (see `extra-vs-spells.lua`), please open a PR and I'll add them.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ In the US, see e.g. [Galoob v. Nintendo](https://www.lexisnexis.com/community/ca
 
 # Getting it running
 
-To expose VenturePlan's internal data you will need to edit its source code. First, ensure that you are on the latest version, `4.16a`. Then open up `Interface/Addons/VenturePlan/vs.lua` in a text editor, and insert the line `_G[_] = T` in the first blank space. It should look like this when you're done:
+To expose VenturePlan's internal data you will need to edit its source code. First, ensure that you are on the latest version, `4.16a`. Then open up `_retail_/Interface/AddOns/VenturePlan/vs.lua` in a text editor, and insert the line `_G[_] = T` in the first blank space. It should look like this when you're done:
 
 ![Notepad preview of changed file](img/notepad.png)
 


### PR DESCRIPTION
Renown level 62 will give you your 21st follower, and VenturePlan is hard coded for a maximum of 20. This raises the max to 99 in a for loop.

Thanks for all of your work keeping this thing running - much appreciated.

EDIT: I wish I'd read the issues here before poking through the code, but... fixes #33 